### PR TITLE
Add Verb to Skills

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -15,7 +15,7 @@ class MembersController < ApplicationController
     @member_band = MemberBand.new(band_id: params[:band_id], skill_id: params[:skill_id], member_id: params[:id], joined_band_at: Time.now)
     if @member_band.save
       current_manager.financials.create!(amount: -@member_band.member.cost_generator, band_id: params[:band_id])
-      @member_band.band.happenings.create(what: "#{@member_band.member.name} was hired to play #{@member_band.member.primary_skill.name}!")
+      @member_band.band.happenings.create(what: "#{@member_band.member.name} was hired to #{member_band.member.primary_skill.verb} #{@member_band.member.primary_skill.name}!")
       redirect_to band_path(params[:band_id]), alert: "Member hired successfully."
     else
       redirect_to new_band_path, alert: "Error hiring member."

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -4,11 +4,14 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  name       :string
+#  verb       :string           default("play")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
 
 class Skill < ApplicationRecord
+  ensure_by :id, :name
+
   has_many :genre_skills
   has_many :genres, through: :genre_skills
   has_many :member_skills

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,8 @@ module Rockburg
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # ActiveRecord time_zone
+    config.active_record.default_timezone = :utc
+    config.active_record.time_zone_aware_types = %i[datetime time]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,16 @@
 require_relative 'boot'
 
-require 'rails/all'
+# Pick the frameworks you want:
+require "active_model/railtie"
+# require "active_job/railtie"
+require "active_record/railtie"
+# require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "action_cable/engine"
+require "sprockets/railtie"
+# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -9,11 +19,7 @@ Bundler.require(*Rails.groups)
 module Rockburg
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 5.2
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-    config.autoload_paths += %W[#{config.root}/app/workers]
   end
 end

--- a/db/migrate/20180413001352_add_verb_to_skills.rb
+++ b/db/migrate/20180413001352_add_verb_to_skills.rb
@@ -1,0 +1,5 @@
+class AddVerbToSkills < ActiveRecord::Migration[5.2]
+  def change
+    add_column :skills, :verb, :string, default: 'play'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_09_213912) do
+ActiveRecord::Schema.define(version: 2018_04_13_001352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 2018_04_09_213912) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "verb", default: "play"
   end
 
   create_table "song_recordings", force: :cascade do |t|

--- a/db/seeds/skills.seeds.rb
+++ b/db/seeds/skills.seeds.rb
@@ -1,0 +1,17 @@
+after :genres do
+  puts "Update Verbs on Skills"
+  seed_data = {
+    'sing' => ['Backup Vocals', 'Vocals'],
+    nil => ['Dance','DJ','Rapping']
+  }
+
+  seed_data.each do |k,v|
+    v.each do |skill_name|
+      skill = Skill.ensure(skill_name)
+      skill.verb = k
+      skill.save
+      puts "  #{skill.name} Verb(#{skill.verb})".blue
+    end
+  end
+  puts
+end

--- a/spec/factories/skills.rb
+++ b/spec/factories/skills.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  name       :string
+#  verb       :string           default("play")
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #


### PR DESCRIPTION
- removed ActiveJob from requirements (since you know you want to use Sidekiq)
- removed ActiveStorage from startup requirements (for now) until you need it
- set default timezone for data storage to UTC

- added a migration to add a verb to Skills so that the news can read better
"Biff Wellington was hired to play Vocals! " will now read "Biff Wellington was hired to sing Vocals!"
Still have a problem with `Rapping` -- perhaps the skill should be just `Rap` then it would read:
"Biff Wellington was hired to Rap!"

