### PR TITLE
add game:reset rake task

### DIFF
--- a/app/controllers/bands_controller.rb
+++ b/app/controllers/bands_controller.rb
@@ -25,7 +25,11 @@ class BandsController < ApplicationController
   end
 
   def show
-    @band = Band.find(params[:id])
+    @band = Band.where(id: params[:id]).first
+    if !@band
+      redirect_to dashboard_path
+      return
+    end
     @activity = @band.activities.current_activity.try(:last)
   end
 

--- a/app/models/game_datum.rb
+++ b/app/models/game_datum.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: game_data
+#
+#  id         :bigint(8)        not null, primary key
+#  key        :string
+#  value      :jsonb
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_game_data_on_key  (key) UNIQUE
+#
+
+class GameDatum < ApplicationRecord
+
+  def self.get(key)
+    self.where(key: key).first&.value
+  end
+
+  def self.set(key, value)
+    record = self.where(key: key).first_or_create
+    record.update(value: value)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,8 @@
       </div>
       <ul class="navbar-nav flex-row ml-md-auto d-none d-md-flex">
         <li class="nav-item py-2 px-4">
-          <small class="text-light">Game last reset <b><u><%= time_ago_in_words('2018-04-13 15:51:17 -0500', vague: true) %> ago</u></b></small>
+          <%- last_reset = Time.parse(GameDatum.get(:last_reset) ||' 2018-04-13 15:51:17 -0500')%>
+          <small class="text-light">Game last reset <b><u><%= time_ago_in_words(last_reset, vague: true) %> ago</u></b></small>
         </li>
         <li class="nav-item">
           <a href="#" role="button" class="text-light nav-link btn btn-success">Money <span class="badge badge-light"><%= as_game_currency(current_manager.balance) %></span></a>

--- a/db/migrate/20180417230557_create_game_data.rb
+++ b/db/migrate/20180417230557_create_game_data.rb
@@ -1,0 +1,11 @@
+class CreateGameData < ActiveRecord::Migration[5.2]
+  def change
+    create_table :game_data do |t|
+      t.string :key
+      t.jsonb :value
+
+      t.timestamps
+    end
+    add_index :game_data, :key, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_17_131111) do
+ActiveRecord::Schema.define(version: 2018_04_17_230557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,14 @@ ActiveRecord::Schema.define(version: 2018_04_17_131111) do
     t.index ["activity_id"], name: "index_financials_on_activity_id"
     t.index ["band_id"], name: "index_financials_on_band_id"
     t.index ["manager_id"], name: "index_financials_on_manager_id"
+  end
+
+  create_table "game_data", force: :cascade do |t|
+    t.string "key"
+    t.jsonb "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_game_data_on_key", unique: true
   end
 
   create_table "genre_skills", force: :cascade do |t|

--- a/lib/tasks/game.rake
+++ b/lib/tasks/game.rake
@@ -1,0 +1,29 @@
+namespace :game do
+  desc 'Reset everything except the Manager profiles'
+  task :reset => :environment do
+    puts "  Deleteing Members".yellow
+    Member.delete_all
+
+    puts "  Deleteing Game State".yellow
+    MemberBand.delete_all
+    Band.delete_all
+    Financial.delete_all
+    Activity.delete_all
+    Gig.delete_all
+    Recording.delete_all
+    SongRecording.delete_all
+    Song.delete_all
+    SingleAlbum.delete_all
+
+    puts "  Setting Starting Balance on Existing Managers".yellow
+    Manager.find_each do |manager|
+      manager.give_starting_balance
+    end
+
+    puts "  Creating New Members".yellow
+    Rake::Task["db:seed:members"].invoke
+    puts
+
+    GameDatum.set(:last_reset, Time.now.utc)
+  end
+end


### PR DESCRIPTION
- add rake task `game:reset`
 - deletes everything except Manager profiles
 - recreates 500 new Members (after removing the old ones)
 - reset Manager balance to 50k
 - redirects to manager dashboard if band page is for deleted band
 - added a `GameDatum` model for holding things like `last_reset` which displays in the top bar correctly after a reset
