### PR TITLE
Fix charts controller tests.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,9 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  # Include Devise test helpers.
+  config.include Devise::Test::ControllerHelpers, type: :controller
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
The tests were failing because of a missing Devise configuration for
Rspec.