### PR TITLE
Fix Rails version configured for Rubocop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   TargetRubyVersion: ~
-  TargetRailsVersion: 5.0
+  TargetRailsVersion: 5.2
   Exclude:
     - '**/bin/**/*'
     - '**/db/**/*'


### PR DESCRIPTION
Configure Rubocop to target the very same Rails version used by the
project making sure cops explicitly aiming Rails 5.2 will not be
ignored.