### PR TITLE
Fixing the scopes on managers controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,9 @@ group :development, :test do
 end
 
 group :test do
-  gem 'rspec-sidekiq'
   gem 'pundit-matchers'
+  gem 'rails-controller-testing'
+  gem 'rspec-sidekiq'
   gem 'rspec_junit_formatter'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -409,6 +413,7 @@ DEPENDENCIES
   pundit
   pundit-matchers
   rails (~> 5.2)
+  rails-controller-testing
   rspec-rails
   rspec-sidekiq
   rspec_junit_formatter

--- a/app/controllers/managers_controller.rb
+++ b/app/controllers/managers_controller.rb
@@ -2,9 +2,10 @@ class ManagersController < ApplicationController
   before_action :authenticate_manager!, except: [:show]
 
   def index
-    @manager = authorize(current_manager)
-    @bands = policy_scope(Band).all
+    @manager = current_manager
+    @bands = policy_scope(Band).where(manager_id: current_manager.id).all
     @badges = current_manager.badges
+
     render(:action => 'show')
   end
 

--- a/spec/controllers/managers_controller_spec.rb
+++ b/spec/controllers/managers_controller_spec.rb
@@ -1,18 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe ManagersController, type: :controller do
-  let(:current_manager) { create(:manager) }
+  let!(:current_manager) { create(:manager) }
+  let!(:band) { create(:band, manager: current_manager) }
 
   before do
     @other_managers = create_list(:manager, 5)
+    @other_managers.each do |manager|
+      create(:band, manager: manager)
+    end
     sign_in current_manager
   end
 
   context '#index' do
-    before { get(:index) }
+    subject { get(:index) }
 
     it 'should return success' do
+      subject
       expect(response.successful?).to eq(true)
+    end
+
+    it 'renders show' do
+      expect(subject).to render_template(:show)
+    end
+
+    it 'should set your bands' do
+      subject
+      expect(assigns(:bands)).to eq current_manager.bands.all
+    end
+
+    it 'should set your badges' do
+      subject
+      expect(assigns(:badges)).to eq current_manager.badges
     end
   end
 


### PR DESCRIPTION
This fixes the scope to only return your own bands. Also adds a scope test for it. This comes down to the fact that previously I had the `ManagerPolicy` set to only return the manager's own bands. But after looking at it most read-only information was public so the scope was extended back to all.

