### PR TITLE
Ensure we redirect with an error if they don't have access

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :set_last_seen_at, if: proc { manager_signed_in? }
   after_action :verify_authorized, except: :index, unless: :devise_controller?
   after_action :verify_policy_scoped, only: :index, unless: :devise_controller?
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def current_user
     current_manager
@@ -29,5 +30,10 @@ class ApplicationController < ActionController::Base
 
   def set_last_seen_at
     current_manager.update_attribute(:last_seen_at, Time.current)
+  end
+
+  def user_not_authorized
+    flash[:alert] = "Woah! It looks like you can't do this."
+    redirect_to(request.referrer || root_path)
   end
 end

--- a/spec/controllers/activities_controller_spec.rb
+++ b/spec/controllers/activities_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActivitiesController, type: :controller do
       subject { get(:new, params: { band_id: band.id, type: :practice, hours: 1.minute } ) }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe ActivitiesController, type: :controller do
       before { sign_in current_manager }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
   end
@@ -62,7 +62,7 @@ RSpec.describe ActivitiesController, type: :controller do
       subject { get(:new, params: { band_id: band.id, type: :write_song, hours: 1.minute } ) }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe ActivitiesController, type: :controller do
       before { sign_in current_manager }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe ActivitiesController, type: :controller do
       subject { get(:new, params: { band_id: band.id, type: :gig, venue: venue, hours: 1.minute } ) }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe ActivitiesController, type: :controller do
       before { sign_in current_manager }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
   end
@@ -137,7 +137,7 @@ RSpec.describe ActivitiesController, type: :controller do
       subject { get(:new, params: { band_id: band.id, type: :release, recording_ids: [recording.id], release: { name: Faker::FunnyName.name, kind: :album }, hours: 1.minute } ) }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
 
@@ -165,7 +165,7 @@ RSpec.describe ActivitiesController, type: :controller do
       end
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
   end
@@ -175,7 +175,7 @@ RSpec.describe ActivitiesController, type: :controller do
       subject { get(:new, params: { band_id: band.id, type: :rest, hours: 1.minute } ) }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
 
@@ -200,7 +200,7 @@ RSpec.describe ActivitiesController, type: :controller do
       before { sign_in current_manager }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
   end

--- a/spec/controllers/bands_controller_spec.rb
+++ b/spec/controllers/bands_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BandsController, type: :controller do
 
     context 'anonymous' do
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
 
@@ -44,7 +44,7 @@ RSpec.describe BandsController, type: :controller do
       subject { post(:create, params: { band: band } ) }
 
       it 'is not allowed' do
-        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+        expect(subject).to redirect_to(root_url)
       end
     end
 

--- a/spec/controllers/recordings_controller_spec.rb
+++ b/spec/controllers/recordings_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RecordingsController, type: :controller do
 
     # context 'anonymous' do
     #   it 'should redirect' do
-    #     expect { subject }.to raise_error(Pundit::NotAuthorizedError)
+    #     expect(subject).to redirect_to(root_url)
     #   end
     # end
 


### PR DESCRIPTION
Instead of just throwing an exception this will redirect with an alert message when access isn't granted.

<img width="1168" alt="screen shot 2019-01-14 at 8 12 42 pm" src="https://user-images.githubusercontent.com/125599/51151451-eb835a00-1838-11e9-8882-0cda967cc70b.png">
